### PR TITLE
Rework to store controllers using string ids

### DIFF
--- a/Assets/UGF.Module.Controllers.Runtime.Tests/Resources/Module.asset
+++ b/Assets/UGF.Module.Controllers.Runtime.Tests/Resources/Module.asset
@@ -13,7 +13,5 @@ MonoBehaviour:
   m_Name: Module
   m_EditorClassIdentifier: 
   m_controllers:
-  - m_guid:
-      m_first: 5630805715589052298
-      m_second: 7100399218970679929
+  - m_guid: 0cecb78aa3f74e24795a355a78af8962
     m_asset: {fileID: 11400000, guid: 0cecb78aa3f74e24795a355a78af8962, type: 2}

--- a/Assets/UGF.Module.Controllers.Runtime.Tests/TestControllerModule.cs
+++ b/Assets/UGF.Module.Controllers.Runtime.Tests/TestControllerModule.cs
@@ -1,6 +1,5 @@
 using NUnit.Framework;
 using UGF.Application.Runtime;
-using UGF.EditorTools.Runtime.Ids;
 using UnityEngine;
 
 namespace UGF.Module.Controllers.Runtime.Tests
@@ -17,7 +16,7 @@ namespace UGF.Module.Controllers.Runtime.Tests
             var module = application.GetModule<IControllerModule>();
 
             Assert.NotNull(module);
-            Assert.True(module.Provider.Controllers.ContainsKey(new GlobalId("0cecb78aa3f74e24795a355a78af8962")));
+            Assert.True(module.Provider.Controllers.ContainsKey("0cecb78aa3f74e24795a355a78af8962"));
 
             application.Uninitialize();
         }

--- a/Packages/UGF.Module.Controllers/Editor/ControllerModuleAssetEditor.cs
+++ b/Packages/UGF.Module.Controllers/Editor/ControllerModuleAssetEditor.cs
@@ -1,4 +1,4 @@
-using UGF.EditorTools.Editor.Assets;
+using UGF.EditorTools.Editor.IMGUI.AssetReferences;
 using UGF.EditorTools.Editor.IMGUI.Scopes;
 using UGF.Module.Controllers.Runtime;
 using UnityEditor;
@@ -9,12 +9,12 @@ namespace UGF.Module.Controllers.Editor
     internal class ControllerModuleAssetEditor : UnityEditor.Editor
     {
         private SerializedProperty m_propertyScript;
-        private AssetIdReferenceListDrawer m_listControllers;
+        private AssetReferenceListDrawer m_listControllers;
 
         private void OnEnable()
         {
             m_propertyScript = serializedObject.FindProperty("m_Script");
-            m_listControllers = new AssetIdReferenceListDrawer(serializedObject.FindProperty("m_controllers"));
+            m_listControllers = new AssetReferenceListDrawer(serializedObject.FindProperty("m_controllers"));
 
             m_listControllers.Enable();
         }

--- a/Packages/UGF.Module.Controllers/Runtime/ControllerModule.cs
+++ b/Packages/UGF.Module.Controllers/Runtime/ControllerModule.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using UGF.Application.Runtime;
-using UGF.EditorTools.Runtime.Ids;
 using UGF.Logs.Runtime;
 
 namespace UGF.Module.Controllers.Runtime
@@ -30,7 +29,7 @@ namespace UGF.Module.Controllers.Runtime
                 controllers = Description.Controllers.Count
             });
 
-            foreach (KeyValuePair<GlobalId, IControllerBuilder> pair in Description.Controllers)
+            foreach (KeyValuePair<string, IControllerBuilder> pair in Description.Controllers)
             {
                 IController controller = pair.Value.Build(Application);
 

--- a/Packages/UGF.Module.Controllers/Runtime/ControllerModuleAsset.cs
+++ b/Packages/UGF.Module.Controllers/Runtime/ControllerModuleAsset.cs
@@ -1,6 +1,6 @@
 using System.Collections.Generic;
 using UGF.Application.Runtime;
-using UGF.EditorTools.Runtime.Assets;
+using UGF.EditorTools.Runtime.IMGUI.AssetReferences;
 using UnityEngine;
 
 namespace UGF.Module.Controllers.Runtime
@@ -8,17 +8,20 @@ namespace UGF.Module.Controllers.Runtime
     [CreateAssetMenu(menuName = "Unity Game Framework/Controllers/Controller Module", order = 2000)]
     public class ControllerModuleAsset : ApplicationModuleAsset<IControllerModule, ControllerModuleDescription>
     {
-        [SerializeField] private List<AssetIdReference<ControllerAsset>> m_controllers = new List<AssetIdReference<ControllerAsset>>();
+        [SerializeField] private List<AssetReference<ControllerAsset>> m_controllers = new List<AssetReference<ControllerAsset>>();
 
-        public List<AssetIdReference<ControllerAsset>> Controllers { get { return m_controllers; } }
+        public List<AssetReference<ControllerAsset>> Controllers { get { return m_controllers; } }
 
         protected override IApplicationModuleDescription OnBuildDescription()
         {
-            var description = new ControllerModuleDescription(typeof(IControllerModule));
+            var description = new ControllerModuleDescription
+            {
+                RegisterType = typeof(IControllerModule)
+            };
 
             for (int i = 0; i < m_controllers.Count; i++)
             {
-                AssetIdReference<ControllerAsset> reference = m_controllers[i];
+                AssetReference<ControllerAsset> reference = m_controllers[i];
 
                 description.Controllers.Add(reference.Guid, reference.Asset);
             }

--- a/Packages/UGF.Module.Controllers/Runtime/ControllerModuleDescription.cs
+++ b/Packages/UGF.Module.Controllers/Runtime/ControllerModuleDescription.cs
@@ -1,18 +1,12 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using UGF.Application.Runtime;
-using UGF.EditorTools.Runtime.Ids;
 
 namespace UGF.Module.Controllers.Runtime
 {
     public class ControllerModuleDescription : ApplicationModuleDescription, IControllerModuleDescription
     {
-        public Dictionary<GlobalId, IControllerBuilder> Controllers { get; } = new Dictionary<GlobalId, IControllerBuilder>();
+        public Dictionary<string, IControllerBuilder> Controllers { get; } = new Dictionary<string, IControllerBuilder>();
 
-        IReadOnlyDictionary<GlobalId, IControllerBuilder> IControllerModuleDescription.Controllers { get { return Controllers; } }
-
-        public ControllerModuleDescription(Type registerType) : base(registerType)
-        {
-        }
+        IReadOnlyDictionary<string, IControllerBuilder> IControllerModuleDescription.Controllers { get { return Controllers; } }
     }
 }

--- a/Packages/UGF.Module.Controllers/Runtime/ControllerProvider.cs
+++ b/Packages/UGF.Module.Controllers/Runtime/ControllerProvider.cs
@@ -1,21 +1,20 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
-using UGF.EditorTools.Runtime.Ids;
 using UGF.Initialize.Runtime;
 
 namespace UGF.Module.Controllers.Runtime
 {
     public class ControllerProvider : InitializeBase, IControllerProvider
     {
-        public IReadOnlyDictionary<GlobalId, IController> Controllers { get; }
+        public IReadOnlyDictionary<string, IController> Controllers { get; }
 
-        private readonly Dictionary<GlobalId, IController> m_controllers = new Dictionary<GlobalId, IController>();
+        private readonly Dictionary<string, IController> m_controllers = new Dictionary<string, IController>();
         private readonly InitializeCollection<IController> m_initialize = new InitializeCollection<IController>();
 
         public ControllerProvider()
         {
-            Controllers = new ReadOnlyDictionary<GlobalId, IController>(m_controllers);
+            Controllers = new ReadOnlyDictionary<string, IController>(m_controllers);
         }
 
         protected override void OnInitialize()
@@ -32,18 +31,18 @@ namespace UGF.Module.Controllers.Runtime
             m_initialize.Uninitialize();
         }
 
-        public void Add(GlobalId id, IController controller)
+        public void Add(string id, IController controller)
         {
-            if (id.IsEmpty) throw new ArgumentException("Value cannot be null or empty.", nameof(id));
+            if (string.IsNullOrEmpty(id)) throw new ArgumentException("Value cannot be null or empty.", nameof(id));
             if (controller == null) throw new ArgumentNullException(nameof(controller));
 
             m_controllers.Add(id, controller);
             m_initialize.Add(controller);
         }
 
-        public bool Remove(GlobalId id)
+        public bool Remove(string id)
         {
-            if (id.IsEmpty) throw new ArgumentException("Value cannot be null or empty.", nameof(id));
+            if (string.IsNullOrEmpty(id)) throw new ArgumentException("Value cannot be null or empty.", nameof(id));
 
             if (TryGet(id, out IController controller))
             {
@@ -61,17 +60,17 @@ namespace UGF.Module.Controllers.Runtime
             m_initialize.Clear();
         }
 
-        public T Get<T>(GlobalId id) where T : class, IController
+        public T Get<T>(string id) where T : class, IController
         {
             return (T)Get(id);
         }
 
-        public IController Get(GlobalId id)
+        public IController Get(string id)
         {
             return TryGet(id, out IController value) ? value : throw new ArgumentException($"Controller not found by the specified id: '{id}'.");
         }
 
-        public bool TryGet<T>(GlobalId id, out T controller) where T : class, IController
+        public bool TryGet<T>(string id, out T controller) where T : class, IController
         {
             if (TryGet(id, out IController value))
             {
@@ -83,14 +82,14 @@ namespace UGF.Module.Controllers.Runtime
             return false;
         }
 
-        public bool TryGet(GlobalId id, out IController controller)
+        public bool TryGet(string id, out IController controller)
         {
-            if (id.IsEmpty) throw new ArgumentException("Value cannot be null or empty.", nameof(id));
+            if (string.IsNullOrEmpty(id)) throw new ArgumentException("Value cannot be null or empty.", nameof(id));
 
             return m_controllers.TryGetValue(id, out controller);
         }
 
-        public Dictionary<GlobalId, IController>.Enumerator GetEnumerator()
+        public Dictionary<string, IController>.Enumerator GetEnumerator()
         {
             return m_controllers.GetEnumerator();
         }

--- a/Packages/UGF.Module.Controllers/Runtime/IControllerModuleDescription.cs
+++ b/Packages/UGF.Module.Controllers/Runtime/IControllerModuleDescription.cs
@@ -1,11 +1,10 @@
 ﻿using System.Collections.Generic;
 using UGF.Application.Runtime;
-using UGF.EditorTools.Runtime.Ids;
 
 namespace UGF.Module.Controllers.Runtime
 {
     public interface IControllerModuleDescription : IApplicationModuleDescription
     {
-        IReadOnlyDictionary<GlobalId, IControllerBuilder> Controllers { get; }
+        IReadOnlyDictionary<string, IControllerBuilder> Controllers { get; }
     }
 }

--- a/Packages/UGF.Module.Controllers/Runtime/IControllerProvider.cs
+++ b/Packages/UGF.Module.Controllers/Runtime/IControllerProvider.cs
@@ -1,19 +1,18 @@
 ﻿using System.Collections.Generic;
-using UGF.EditorTools.Runtime.Ids;
 using UGF.Initialize.Runtime;
 
 namespace UGF.Module.Controllers.Runtime
 {
     public interface IControllerProvider : IInitialize
     {
-        IReadOnlyDictionary<GlobalId, IController> Controllers { get; }
+        IReadOnlyDictionary<string, IController> Controllers { get; }
 
-        void Add(GlobalId id, IController controller);
-        bool Remove(GlobalId id);
+        void Add(string id, IController controller);
+        bool Remove(string id);
         void Clear();
-        T Get<T>(GlobalId id) where T : class, IController;
-        IController Get(GlobalId id);
-        bool TryGet<T>(GlobalId id, out T controller) where T : class, IController;
-        bool TryGet(GlobalId id, out IController controller);
+        T Get<T>(string id) where T : class, IController;
+        IController Get(string id);
+        bool TryGet<T>(string id, out T controller) where T : class, IController;
+        bool TryGet(string id, out IController controller);
     }
 }

--- a/Packages/UGF.Module.Controllers/package.json
+++ b/Packages/UGF.Module.Controllers/package.json
@@ -22,8 +22,7 @@
     "registry": "https://api.bintray.com/content/unity-game-framework/public"
   },
   "dependencies": {
-    "com.ugf.application": "7.0.0",
-    "com.ugf.logs": "5.0.0",
+    "com.ugf.application": "7.1.0",
     "com.ugf.editortools": "1.8.1"
   }
 }

--- a/Packages/UGF.Module.Controllers/package.json
+++ b/Packages/UGF.Module.Controllers/package.json
@@ -22,8 +22,8 @@
     "registry": "https://api.bintray.com/content/unity-game-framework/public"
   },
   "dependencies": {
-    "com.ugf.application": "6.0.0",
-    "com.ugf.logs": "4.1.0",
-    "com.ugf.editortools": "1.8.0"
+    "com.ugf.application": "7.0.0",
+    "com.ugf.logs": "5.0.0",
+    "com.ugf.editortools": "1.8.1"
   }
 }

--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
     "com.unity.ide.rider": "3.0.3",
-    "com.unity.test-framework": "1.1.19"
+    "com.unity.test-framework": "1.1.20"
   },
   "scopedRegistries": [
     {

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -1,13 +1,14 @@
 {
   "dependencies": {
     "com.ugf.application": {
-      "version": "7.0.0",
+      "version": "7.1.0",
       "depth": 1,
       "source": "registry",
       "dependencies": {
         "com.ugf.initialize": "2.6.0",
         "com.ugf.description": "2.0.0",
-        "com.ugf.customsettings": "3.4.0"
+        "com.ugf.customsettings": "3.4.0",
+        "com.ugf.logs": "5.1.0"
       },
       "url": "https://api.bintray.com/npm/unity-game-framework/public"
     },
@@ -29,7 +30,7 @@
     },
     "com.ugf.defines": {
       "version": "2.1.0",
-      "depth": 2,
+      "depth": 3,
       "source": "registry",
       "dependencies": {
         "com.ugf.customsettings": "3.4.0"
@@ -60,8 +61,8 @@
       "url": "https://api.bintray.com/npm/unity-game-framework/public"
     },
     "com.ugf.logs": {
-      "version": "5.0.0",
-      "depth": 1,
+      "version": "5.1.0",
+      "depth": 2,
       "source": "registry",
       "dependencies": {
         "com.ugf.defines": "2.1.0"
@@ -73,8 +74,7 @@
       "depth": 0,
       "source": "embedded",
       "dependencies": {
-        "com.ugf.application": "7.0.0",
-        "com.ugf.logs": "5.0.0",
+        "com.ugf.application": "7.1.0",
         "com.ugf.editortools": "1.8.1"
       }
     },

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
     "com.ugf.application": {
-      "version": "6.0.0",
+      "version": "7.0.0",
       "depth": 1,
       "source": "registry",
       "dependencies": {
@@ -46,7 +46,7 @@
       "url": "https://api.bintray.com/npm/unity-game-framework/public"
     },
     "com.ugf.editortools": {
-      "version": "1.8.0",
+      "version": "1.8.1",
       "depth": 1,
       "source": "registry",
       "dependencies": {},
@@ -60,7 +60,7 @@
       "url": "https://api.bintray.com/npm/unity-game-framework/public"
     },
     "com.ugf.logs": {
-      "version": "4.1.0",
+      "version": "5.0.0",
       "depth": 1,
       "source": "registry",
       "dependencies": {
@@ -73,13 +73,13 @@
       "depth": 0,
       "source": "embedded",
       "dependencies": {
-        "com.ugf.application": "6.0.0",
-        "com.ugf.logs": "4.1.0",
-        "com.ugf.editortools": "1.8.0"
+        "com.ugf.application": "7.0.0",
+        "com.ugf.logs": "5.0.0",
+        "com.ugf.editortools": "1.8.1"
       }
     },
     "com.unity.ext.nunit": {
-      "version": "1.0.5",
+      "version": "1.0.6",
       "depth": 1,
       "source": "registry",
       "dependencies": {},
@@ -95,11 +95,11 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.test-framework": {
-      "version": "1.1.19",
+      "version": "1.1.20",
       "depth": 0,
       "source": "registry",
       "dependencies": {
-        "com.unity.ext.nunit": "1.0.5",
+        "com.unity.ext.nunit": "1.0.6",
         "com.unity.modules.imgui": "1.0.0",
         "com.unity.modules.jsonserialize": "1.0.0"
       },

--- a/ProjectSettings/ProjectVersion.txt
+++ b/ProjectSettings/ProjectVersion.txt
@@ -1,2 +1,2 @@
-m_EditorVersion: 2020.2.0f1
-m_EditorVersionWithRevision: 2020.2.0f1 (3721df5a8b28)
+m_EditorVersion: 2020.2.1f1
+m_EditorVersionWithRevision: 2020.2.1f1 (270dd8c3da1c)


### PR DESCRIPTION
- Rework provider and module to work with `string` as controller _id_ instead of `GlobalId` structure.