### PR TITLE
Add controller collection asset

### DIFF
--- a/Assets/UGF.Module.Controllers.Runtime.Tests/New Controller Collection Asset.asset
+++ b/Assets/UGF.Module.Controllers.Runtime.Tests/New Controller Collection Asset.asset
@@ -9,11 +9,9 @@ MonoBehaviour:
   m_GameObject: {fileID: 0}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 1de5679fff5bc8244a38027f3b0f2c8d, type: 3}
-  m_Name: New Controller Module Asset
+  m_Script: {fileID: 11500000, guid: 112f7a176872486996125cd9edf35b60, type: 3}
+  m_Name: New Controller Collection Asset
   m_EditorClassIdentifier: 
   m_controllers:
   - m_guid: 0cecb78aa3f74e24795a355a78af8962
     m_asset: {fileID: 11400000, guid: 0cecb78aa3f74e24795a355a78af8962, type: 2}
-  m_collections:
-  - {fileID: 11400000, guid: 37795c34eabcbf54d9cc4eb928a9ed60, type: 2}

--- a/Assets/UGF.Module.Controllers.Runtime.Tests/New Controller Collection Asset.asset.meta
+++ b/Assets/UGF.Module.Controllers.Runtime.Tests/New Controller Collection Asset.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 37795c34eabcbf54d9cc4eb928a9ed60
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/UGF.Module.Controllers.Runtime.Tests/Resources/Collection.asset
+++ b/Assets/UGF.Module.Controllers.Runtime.Tests/Resources/Collection.asset
@@ -9,11 +9,9 @@ MonoBehaviour:
   m_GameObject: {fileID: 0}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 1de5679fff5bc8244a38027f3b0f2c8d, type: 3}
-  m_Name: Module
+  m_Script: {fileID: 11500000, guid: 112f7a176872486996125cd9edf35b60, type: 3}
+  m_Name: Collection
   m_EditorClassIdentifier: 
   m_controllers:
-  - m_guid: 0cecb78aa3f74e24795a355a78af8962
-    m_asset: {fileID: 11400000, guid: 0cecb78aa3f74e24795a355a78af8962, type: 2}
-  m_collections:
-  - {fileID: 11400000, guid: 1ec1f2a28bf419843a8473c1b41f2752, type: 2}
+  - m_guid: c2d5c18bfe7d70c4ca76a2ae4dad42ba
+    m_asset: {fileID: 11400000, guid: c2d5c18bfe7d70c4ca76a2ae4dad42ba, type: 2}

--- a/Assets/UGF.Module.Controllers.Runtime.Tests/Resources/Collection.asset.meta
+++ b/Assets/UGF.Module.Controllers.Runtime.Tests/Resources/Collection.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 1ec1f2a28bf419843a8473c1b41f2752
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/UGF.Module.Controllers.Runtime.Tests/Resources/Controller_2.asset
+++ b/Assets/UGF.Module.Controllers.Runtime.Tests/Resources/Controller_2.asset
@@ -1,0 +1,14 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f4aa58be9d2439c91b8fb24fb71ea4e, type: 3}
+  m_Name: Controller_2
+  m_EditorClassIdentifier: 

--- a/Assets/UGF.Module.Controllers.Runtime.Tests/Resources/Controller_2.asset.meta
+++ b/Assets/UGF.Module.Controllers.Runtime.Tests/Resources/Controller_2.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: c2d5c18bfe7d70c4ca76a2ae4dad42ba
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/UGF.Module.Controllers/Editor/ControllerCollectionAssetEditor.cs
+++ b/Packages/UGF.Module.Controllers/Editor/ControllerCollectionAssetEditor.cs
@@ -1,0 +1,32 @@
+﻿using UGF.EditorTools.Editor.IMGUI.Scopes;
+using UGF.Module.Controllers.Runtime;
+using UnityEditor;
+
+namespace UGF.Module.Controllers.Editor
+{
+    [CustomEditor(typeof(ControllerCollectionAsset), true)]
+    internal class ControllerCollectionAssetEditor : UnityEditor.Editor
+    {
+        private ControllerModuleControllerListDrawer m_listControllers;
+
+        private void OnEnable()
+        {
+            m_listControllers = new ControllerModuleControllerListDrawer(serializedObject.FindProperty("m_controllers"));
+            m_listControllers.Enable();
+        }
+
+        private void OnDisable()
+        {
+            m_listControllers.Disable();
+        }
+
+        public override void OnInspectorGUI()
+        {
+            using (new SerializedObjectUpdateScope(serializedObject))
+            {
+                m_listControllers.DrawGUILayout();
+                m_listControllers.DrawSelectedLayout();
+            }
+        }
+    }
+}

--- a/Packages/UGF.Module.Controllers/Editor/ControllerCollectionAssetEditor.cs
+++ b/Packages/UGF.Module.Controllers/Editor/ControllerCollectionAssetEditor.cs
@@ -1,4 +1,5 @@
-﻿using UGF.EditorTools.Editor.IMGUI.Scopes;
+﻿using UGF.EditorTools.Editor.IMGUI;
+using UGF.EditorTools.Editor.IMGUI.Scopes;
 using UGF.Module.Controllers.Runtime;
 using UnityEditor;
 
@@ -24,6 +25,8 @@ namespace UGF.Module.Controllers.Editor
         {
             using (new SerializedObjectUpdateScope(serializedObject))
             {
+                EditorIMGUIUtility.DrawScriptProperty(serializedObject);
+
                 m_listControllers.DrawGUILayout();
                 m_listControllers.DrawSelectedLayout();
             }

--- a/Packages/UGF.Module.Controllers/Editor/ControllerCollectionAssetEditor.cs.meta
+++ b/Packages/UGF.Module.Controllers/Editor/ControllerCollectionAssetEditor.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 6980b279a2a54388a0e1824cca166bd0
+timeCreated: 1632593010

--- a/Packages/UGF.Module.Controllers/Editor/ControllerModuleAssetEditor.cs
+++ b/Packages/UGF.Module.Controllers/Editor/ControllerModuleAssetEditor.cs
@@ -9,18 +9,22 @@ namespace UGF.Module.Controllers.Editor
     {
         private SerializedProperty m_propertyScript;
         private ControllerModuleControllerListDrawer m_listControllers;
+        private ControllerModuleCollectionListDrawer m_listCollections;
 
         private void OnEnable()
         {
             m_propertyScript = serializedObject.FindProperty("m_Script");
             m_listControllers = new ControllerModuleControllerListDrawer(serializedObject.FindProperty("m_controllers"));
+            m_listCollections = new ControllerModuleCollectionListDrawer(serializedObject.FindProperty("m_collections"));
 
             m_listControllers.Enable();
+            m_listCollections.Enable();
         }
 
         private void OnDisable()
         {
             m_listControllers.Disable();
+            m_listCollections.Disable();
         }
 
         public override void OnInspectorGUI()
@@ -33,7 +37,10 @@ namespace UGF.Module.Controllers.Editor
                 }
 
                 m_listControllers.DrawGUILayout();
+                m_listCollections.DrawGUILayout();
+
                 m_listControllers.DrawSelectedLayout();
+                m_listCollections.DrawSelectedLayout();
             }
         }
     }

--- a/Packages/UGF.Module.Controllers/Editor/ControllerModuleCollectionListDrawer.cs
+++ b/Packages/UGF.Module.Controllers/Editor/ControllerModuleCollectionListDrawer.cs
@@ -1,0 +1,71 @@
+﻿using UGF.EditorTools.Editor.IMGUI;
+using UnityEditor;
+
+namespace UGF.Module.Controllers.Editor
+{
+    internal class ControllerModuleCollectionListDrawer : ReorderableListDrawer
+    {
+        public EditorDrawer Drawer { get; } = new EditorDrawer
+        {
+            DisplayTitlebar = true
+        };
+
+        public ControllerModuleCollectionListDrawer(SerializedProperty serializedProperty) : base(serializedProperty)
+        {
+        }
+
+        protected override void OnEnable()
+        {
+            base.OnEnable();
+
+            Drawer.Enable();
+        }
+
+        protected override void OnDisable()
+        {
+            base.OnDisable();
+
+            Drawer.Disable();
+        }
+
+        protected override void OnRemove()
+        {
+            base.OnRemove();
+
+            UpdateSelection();
+        }
+
+        protected override void OnSelect()
+        {
+            base.OnSelect();
+
+            UpdateSelection();
+        }
+
+        public void DrawSelectedLayout()
+        {
+            Drawer.DrawGUILayout();
+        }
+
+        private void UpdateSelection()
+        {
+            if (List.index >= 0 && List.index < List.count)
+            {
+                SerializedProperty propertyElement = SerializedProperty.GetArrayElementAtIndex(List.index);
+
+                if (propertyElement.objectReferenceValue != null)
+                {
+                    Drawer.Set(propertyElement.objectReferenceValue);
+                }
+                else
+                {
+                    Drawer.Clear();
+                }
+            }
+            else
+            {
+                Drawer.Clear();
+            }
+        }
+    }
+}

--- a/Packages/UGF.Module.Controllers/Editor/ControllerModuleCollectionListDrawer.cs.meta
+++ b/Packages/UGF.Module.Controllers/Editor/ControllerModuleCollectionListDrawer.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: aa75674246384e71a2c482ffa15e9285
+timeCreated: 1632592757

--- a/Packages/UGF.Module.Controllers/Runtime/ControllerCollectionAsset.cs
+++ b/Packages/UGF.Module.Controllers/Runtime/ControllerCollectionAsset.cs
@@ -1,0 +1,14 @@
+﻿using System.Collections.Generic;
+using UGF.EditorTools.Runtime.IMGUI.AssetReferences;
+using UnityEngine;
+
+namespace UGF.Module.Controllers.Runtime
+{
+    [CreateAssetMenu(menuName = "Unity Game Framework/Controllers/Controller Collection", order = 2000)]
+    public class ControllerCollectionAsset : ScriptableObject
+    {
+        [SerializeField] private List<AssetReference<ControllerAsset>> m_controllers = new List<AssetReference<ControllerAsset>>();
+
+        public List<AssetReference<ControllerAsset>> Controllers { get { return m_controllers; } }
+    }
+}

--- a/Packages/UGF.Module.Controllers/Runtime/ControllerCollectionAsset.cs.meta
+++ b/Packages/UGF.Module.Controllers/Runtime/ControllerCollectionAsset.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 112f7a176872486996125cd9edf35b60
+timeCreated: 1632592242

--- a/Packages/UGF.Module.Controllers/Runtime/ControllerCollectionDescription.cs
+++ b/Packages/UGF.Module.Controllers/Runtime/ControllerCollectionDescription.cs
@@ -1,0 +1,11 @@
+﻿using System.Collections.Generic;
+
+namespace UGF.Module.Controllers.Runtime
+{
+    public class ControllerCollectionDescription : IControllerCollectionDescription
+    {
+        public Dictionary<string, IControllerBuilder> Controllers { get; } = new Dictionary<string, IControllerBuilder>();
+
+        IReadOnlyDictionary<string, IControllerBuilder> IControllerCollectionDescription.Controllers { get { return Controllers; } }
+    }
+}

--- a/Packages/UGF.Module.Controllers/Runtime/ControllerCollectionDescription.cs.meta
+++ b/Packages/UGF.Module.Controllers/Runtime/ControllerCollectionDescription.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: abeb144e5b9c47198140eb90d61513b6
+timeCreated: 1632592419

--- a/Packages/UGF.Module.Controllers/Runtime/ControllerModule.cs
+++ b/Packages/UGF.Module.Controllers/Runtime/ControllerModule.cs
@@ -37,6 +37,16 @@ namespace UGF.Module.Controllers.Runtime
                 Provider.Add(pair.Key, controller);
             }
 
+            foreach (IControllerCollectionDescription collection in Description.Collections)
+            {
+                foreach (KeyValuePair<string, IControllerBuilder> pair in collection.Controllers)
+                {
+                    IController controller = pair.Value.Build(Application);
+
+                    Provider.Add(pair.Key, controller);
+                }
+            }
+
             foreach (KeyValuePair<string, IController> pair in Provider.Entries)
             {
                 pair.Value.Initialize();

--- a/Packages/UGF.Module.Controllers/Runtime/ControllerModuleAsset.cs
+++ b/Packages/UGF.Module.Controllers/Runtime/ControllerModuleAsset.cs
@@ -9,8 +9,10 @@ namespace UGF.Module.Controllers.Runtime
     public class ControllerModuleAsset : ApplicationModuleAsset<IControllerModule, ControllerModuleDescription>
     {
         [SerializeField] private List<AssetReference<ControllerAsset>> m_controllers = new List<AssetReference<ControllerAsset>>();
+        [SerializeField] private List<ControllerCollectionAsset> m_collections = new List<ControllerCollectionAsset>();
 
         public List<AssetReference<ControllerAsset>> Controllers { get { return m_controllers; } }
+        public List<ControllerCollectionAsset> Collections { get { return m_collections; } }
 
         protected override IApplicationModuleDescription OnBuildDescription()
         {
@@ -24,6 +26,21 @@ namespace UGF.Module.Controllers.Runtime
                 AssetReference<ControllerAsset> reference = m_controllers[i];
 
                 description.Controllers.Add(reference.Guid, reference.Asset);
+            }
+
+            for (int i = 0; i < m_collections.Count; i++)
+            {
+                ControllerCollectionAsset asset = m_collections[i];
+                var collection = new ControllerCollectionDescription();
+
+                for (int j = 0; j < asset.Controllers.Count; j++)
+                {
+                    AssetReference<ControllerAsset> reference = asset.Controllers[i];
+
+                    collection.Controllers.Add(reference.Guid, reference.Asset);
+                }
+
+                description.Collections.Add(collection);
             }
 
             return description;

--- a/Packages/UGF.Module.Controllers/Runtime/ControllerModuleDescription.cs
+++ b/Packages/UGF.Module.Controllers/Runtime/ControllerModuleDescription.cs
@@ -6,7 +6,9 @@ namespace UGF.Module.Controllers.Runtime
     public class ControllerModuleDescription : ApplicationModuleDescription, IControllerModuleDescription
     {
         public Dictionary<string, IControllerBuilder> Controllers { get; } = new Dictionary<string, IControllerBuilder>();
+        public List<IControllerCollectionDescription> Collections { get; } = new List<IControllerCollectionDescription>();
 
         IReadOnlyDictionary<string, IControllerBuilder> IControllerModuleDescription.Controllers { get { return Controllers; } }
+        IReadOnlyList<IControllerCollectionDescription> IControllerModuleDescription.Collections { get { return Collections; } }
     }
 }

--- a/Packages/UGF.Module.Controllers/Runtime/IControllerCollection.cs
+++ b/Packages/UGF.Module.Controllers/Runtime/IControllerCollection.cs
@@ -1,0 +1,9 @@
+﻿using System.Collections.Generic;
+
+namespace UGF.Module.Controllers.Runtime
+{
+    public interface IControllerCollectionDescription
+    {
+        IReadOnlyDictionary<string, IControllerBuilder> Controllers { get; }
+    }
+}

--- a/Packages/UGF.Module.Controllers/Runtime/IControllerCollection.cs.meta
+++ b/Packages/UGF.Module.Controllers/Runtime/IControllerCollection.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 0317b349fe7147faa9f3305fd2ff27f7
+timeCreated: 1632592357

--- a/Packages/UGF.Module.Controllers/Runtime/IControllerModuleDescription.cs
+++ b/Packages/UGF.Module.Controllers/Runtime/IControllerModuleDescription.cs
@@ -6,5 +6,6 @@ namespace UGF.Module.Controllers.Runtime
     public interface IControllerModuleDescription : IApplicationModuleDescription
     {
         IReadOnlyDictionary<string, IControllerBuilder> Controllers { get; }
+        IReadOnlyList<IControllerCollectionDescription> Collections { get; }
     }
 }

--- a/Packages/UGF.Module.Controllers/package.json
+++ b/Packages/UGF.Module.Controllers/package.json
@@ -19,6 +19,7 @@
     "registry": "https://unitygameframework.jfrog.io/artifactory/api/npm/default"
   },
   "dependencies": {
-    "com.ugf.application": "8.0.0-preview.9"
+    "com.ugf.application": "8.0.0-preview.9",
+    "com.ugf.editortools": "1.13.1"
   }
 }

--- a/Packages/UGF.Module.Controllers/package.json
+++ b/Packages/UGF.Module.Controllers/package.json
@@ -19,6 +19,6 @@
     "registry": "https://unitygameframework.jfrog.io/artifactory/api/npm/default"
   },
   "dependencies": {
-    "com.ugf.application": "8.0.0-preview.8"
+    "com.ugf.application": "8.0.0-preview.9"
   }
 }

--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
     "com.unity.ide.rider": "3.0.7",
-    "com.unity.test-framework": "1.1.27"
+    "com.unity.test-framework": "1.1.29"
   },
   "scopedRegistries": [
     {

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -1,13 +1,13 @@
 {
   "dependencies": {
     "com.ugf.application": {
-      "version": "8.0.0-preview.8",
+      "version": "8.0.0-preview.9",
       "depth": 1,
       "source": "registry",
       "dependencies": {
         "com.ugf.initialize": "2.6.0",
         "com.ugf.description": "2.0.0",
-        "com.ugf.runtimetools": "2.0.0",
+        "com.ugf.runtimetools": "2.2.0",
         "com.ugf.logs": "5.1.4"
       },
       "url": "https://unitygameframework.jfrog.io/artifactory/api/npm/default"
@@ -76,11 +76,11 @@
       "depth": 0,
       "source": "embedded",
       "dependencies": {
-        "com.ugf.application": "8.0.0-preview.8"
+        "com.ugf.application": "8.0.0-preview.9"
       }
     },
     "com.ugf.runtimetools": {
-      "version": "2.0.0",
+      "version": "2.2.0",
       "depth": 2,
       "source": "registry",
       "dependencies": {},

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -103,7 +103,7 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.test-framework": {
-      "version": "1.1.27",
+      "version": "1.1.29",
       "depth": 0,
       "source": "registry",
       "dependencies": {

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -49,8 +49,8 @@
       "url": "https://unitygameframework.jfrog.io/artifactory/api/npm/default"
     },
     "com.ugf.editortools": {
-      "version": "1.11.0",
-      "depth": 4,
+      "version": "1.13.1",
+      "depth": 1,
       "source": "registry",
       "dependencies": {},
       "url": "https://unitygameframework.jfrog.io/artifactory/api/npm/default"
@@ -76,7 +76,8 @@
       "depth": 0,
       "source": "embedded",
       "dependencies": {
-        "com.ugf.application": "8.0.0-preview.9"
+        "com.ugf.application": "8.0.0-preview.9",
+        "com.ugf.editortools": "1.13.1"
       }
     },
     "com.ugf.runtimetools": {

--- a/ProjectSettings/ProjectVersion.txt
+++ b/ProjectSettings/ProjectVersion.txt
@@ -1,2 +1,2 @@
-m_EditorVersion: 2021.1.17f1
-m_EditorVersionWithRevision: 2021.1.17f1 (03b40fe07a36)
+m_EditorVersion: 2021.1.19f1
+m_EditorVersionWithRevision: 2021.1.19f1 (5f5eb8bbdc25)


### PR DESCRIPTION
- Change dependencies: `com.ugf.application` to `8.0.0-preview.9` version and `com.ugf.editortools` to `1.13.1` version.
- Add `ControllerCollectionAsset` class as _ScriptableObject_ asset with list of controller builders.
- Add `ControllerCollectionDescription` class to specify collection of controller for module description.
- Add `ControllerModuleDescription.Collections` property to specify controller collections to create in module.