### PR TITLE
Add controllers async initialization

### DIFF
--- a/Packages/UGF.Module.Controllers/Editor/ControllerModuleAssetEditor.cs
+++ b/Packages/UGF.Module.Controllers/Editor/ControllerModuleAssetEditor.cs
@@ -1,3 +1,4 @@
+using UGF.EditorTools.Editor.IMGUI;
 using UGF.EditorTools.Editor.IMGUI.Scopes;
 using UGF.Module.Controllers.Runtime;
 using UnityEditor;
@@ -8,12 +9,14 @@ namespace UGF.Module.Controllers.Editor
     internal class ControllerModuleAssetEditor : UnityEditor.Editor
     {
         private SerializedProperty m_propertyScript;
+        private SerializedProperty m_propertyUseReverseUninitializationOrder;
         private ControllerModuleControllerListDrawer m_listControllers;
         private ControllerModuleCollectionListDrawer m_listCollections;
 
         private void OnEnable()
         {
             m_propertyScript = serializedObject.FindProperty("m_Script");
+            m_propertyUseReverseUninitializationOrder = serializedObject.FindProperty("m_useReverseUninitializationOrder");
             m_listControllers = new ControllerModuleControllerListDrawer(serializedObject.FindProperty("m_controllers"));
             m_listCollections = new ControllerModuleCollectionListDrawer(serializedObject.FindProperty("m_collections"));
 
@@ -31,10 +34,8 @@ namespace UGF.Module.Controllers.Editor
         {
             using (new SerializedObjectUpdateScope(serializedObject))
             {
-                using (new EditorGUI.DisabledScope(true))
-                {
-                    EditorGUILayout.PropertyField(m_propertyScript);
-                }
+                EditorIMGUIUtility.DrawScriptProperty(serializedObject);
+                EditorGUILayout.PropertyField(m_propertyUseReverseUninitializationOrder);
 
                 m_listControllers.DrawGUILayout();
                 m_listCollections.DrawGUILayout();

--- a/Packages/UGF.Module.Controllers/Runtime/ControllerModule.cs
+++ b/Packages/UGF.Module.Controllers/Runtime/ControllerModule.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using UGF.Application.Runtime;
 using UGF.Initialize.Runtime;
 using UGF.Logs.Runtime;
@@ -7,7 +8,7 @@ using UGF.RuntimeTools.Runtime.Providers;
 
 namespace UGF.Module.Controllers.Runtime
 {
-    public class ControllerModule : ApplicationModule<ControllerModuleDescription>, IControllerModule, IApplicationLauncherEventHandler
+    public class ControllerModule : ApplicationModule<ControllerModuleDescription>, IControllerModule, IApplicationModuleAsync, IApplicationLauncherEventHandler
     {
         public IProvider<string, IController> Provider { get; }
         public IInitializeCollection InitializeCollection { get; }
@@ -51,6 +52,19 @@ namespace UGF.Module.Controllers.Runtime
             }
 
             InitializeCollection.Initialize();
+        }
+
+        public async Task InitializeAsync()
+        {
+            for (int i = 0; i < InitializeCollection.Count; i++)
+            {
+                IInitialize initialize = InitializeCollection[i];
+
+                if (initialize is IControllerAsyncInitialize initializeAsync)
+                {
+                    await initializeAsync.InitializeAsync();
+                }
+            }
         }
 
         protected override void OnUninitialize()

--- a/Packages/UGF.Module.Controllers/Runtime/ControllerModuleAsset.cs
+++ b/Packages/UGF.Module.Controllers/Runtime/ControllerModuleAsset.cs
@@ -8,9 +8,11 @@ namespace UGF.Module.Controllers.Runtime
     [CreateAssetMenu(menuName = "Unity Game Framework/Controllers/Controller Module", order = 2000)]
     public class ControllerModuleAsset : ApplicationModuleAsset<IControllerModule, ControllerModuleDescription>
     {
+        [SerializeField] private bool m_useReverseUninitializationOrder = true;
         [SerializeField] private List<AssetReference<ControllerAsset>> m_controllers = new List<AssetReference<ControllerAsset>>();
         [SerializeField] private List<ControllerCollectionAsset> m_collections = new List<ControllerCollectionAsset>();
 
+        public bool UseReverseUninitializationOrder { get { return m_useReverseUninitializationOrder; } set { m_useReverseUninitializationOrder = value; } }
         public List<AssetReference<ControllerAsset>> Controllers { get { return m_controllers; } }
         public List<ControllerCollectionAsset> Collections { get { return m_collections; } }
 
@@ -18,7 +20,8 @@ namespace UGF.Module.Controllers.Runtime
         {
             var description = new ControllerModuleDescription
             {
-                RegisterType = typeof(IControllerModule)
+                RegisterType = typeof(IControllerModule),
+                UseReverseUninitializationOrder = m_useReverseUninitializationOrder
             };
 
             for (int i = 0; i < m_controllers.Count; i++)

--- a/Packages/UGF.Module.Controllers/Runtime/ControllerModuleDescription.cs
+++ b/Packages/UGF.Module.Controllers/Runtime/ControllerModuleDescription.cs
@@ -5,6 +5,7 @@ namespace UGF.Module.Controllers.Runtime
 {
     public class ControllerModuleDescription : ApplicationModuleDescription, IControllerModuleDescription
     {
+        public bool UseReverseUninitializationOrder { get; set; }
         public Dictionary<string, IControllerBuilder> Controllers { get; } = new Dictionary<string, IControllerBuilder>();
         public List<IControllerCollectionDescription> Collections { get; } = new List<IControllerCollectionDescription>();
 

--- a/Packages/UGF.Module.Controllers/Runtime/IControllerAsyncInitialize.cs
+++ b/Packages/UGF.Module.Controllers/Runtime/IControllerAsyncInitialize.cs
@@ -1,0 +1,9 @@
+﻿using System.Threading.Tasks;
+
+namespace UGF.Module.Controllers.Runtime
+{
+    public interface IControllerAsyncInitialize
+    {
+        Task InitializeAsync();
+    }
+}

--- a/Packages/UGF.Module.Controllers/Runtime/IControllerAsyncInitialize.cs.meta
+++ b/Packages/UGF.Module.Controllers/Runtime/IControllerAsyncInitialize.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 0b1939e445164bdeb4080921204591ec
+timeCreated: 1632594467

--- a/Packages/UGF.Module.Controllers/Runtime/IControllerModule.cs
+++ b/Packages/UGF.Module.Controllers/Runtime/IControllerModule.cs
@@ -1,4 +1,5 @@
 ﻿using UGF.Application.Runtime;
+using UGF.Initialize.Runtime;
 using UGF.RuntimeTools.Runtime.Providers;
 
 namespace UGF.Module.Controllers.Runtime
@@ -7,5 +8,9 @@ namespace UGF.Module.Controllers.Runtime
     {
         new IControllerModuleDescription Description { get; }
         IProvider<string, IController> Provider { get; }
+        IInitializeCollection InitializeCollection { get; }
+
+        void Add(string id, IController controller);
+        bool Remove(string id);
     }
 }


### PR DESCRIPTION
- Add `ControllerModule.InitializeCollection` property to manage initialization order.
- Add `ControllerModule.Add()` and `ControllerModule.Remove()` methods to automatically add controller to provider and initialization collection.
- Add `ControllerModuleDescription.UseReverseUninitializationOrder` property to determine uninitialization order.
- Add `IControllerAsyncInitialize` interface to implement async initialization for controller.