### PR TITLE
Add ObjectRelativesProviderController

### DIFF
--- a/Assets/UGF.Module.Controllers.Runtime.Tests/New Object Relatives Controller Asset.asset
+++ b/Assets/UGF.Module.Controllers.Runtime.Tests/New Object Relatives Controller Asset.asset
@@ -1,0 +1,14 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: defd5b081faf40f6849f735a75278f14, type: 3}
+  m_Name: New Object Relatives Controller Asset
+  m_EditorClassIdentifier: 

--- a/Assets/UGF.Module.Controllers.Runtime.Tests/New Object Relatives Controller Asset.asset.meta
+++ b/Assets/UGF.Module.Controllers.Runtime.Tests/New Object Relatives Controller Asset.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: acd719b44ebcb6145b2948b3cec1161c
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/UGF.Module.Controllers/Runtime/Objects.meta
+++ b/Packages/UGF.Module.Controllers/Runtime/Objects.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: b4b97625ca8a4efa9c441050b478eb73
+timeCreated: 1637930621

--- a/Packages/UGF.Module.Controllers/Runtime/Objects/IObjectRelativesController.cs
+++ b/Packages/UGF.Module.Controllers/Runtime/Objects/IObjectRelativesController.cs
@@ -1,0 +1,9 @@
+﻿using UGF.RuntimeTools.Runtime.Objects;
+
+namespace UGF.Module.Controllers.Runtime.Objects
+{
+    public interface IObjectRelativesController : IController
+    {
+        IObjectRelativeProvider Provider { get; }
+    }
+}

--- a/Packages/UGF.Module.Controllers/Runtime/Objects/IObjectRelativesController.cs.meta
+++ b/Packages/UGF.Module.Controllers/Runtime/Objects/IObjectRelativesController.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: b1cecd28a21e49cc8a7e507ad805019f
+timeCreated: 1637930625

--- a/Packages/UGF.Module.Controllers/Runtime/Objects/ObjectRelativesControllerAsset.cs
+++ b/Packages/UGF.Module.Controllers/Runtime/Objects/ObjectRelativesControllerAsset.cs
@@ -1,0 +1,14 @@
+﻿using UGF.Application.Runtime;
+using UnityEngine;
+
+namespace UGF.Module.Controllers.Runtime.Objects
+{
+    [CreateAssetMenu(menuName = "Unity Game Framework/Controllers/Objects Relatives Controller", order = 2000)]
+    public class ObjectRelativesControllerAsset : ControllerAsset
+    {
+        protected override IController OnBuild(IApplication arguments)
+        {
+            return new ObjectRelativesController<object>(arguments);
+        }
+    }
+}

--- a/Packages/UGF.Module.Controllers/Runtime/Objects/ObjectRelativesControllerAsset.cs.meta
+++ b/Packages/UGF.Module.Controllers/Runtime/Objects/ObjectRelativesControllerAsset.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: defd5b081faf40f6849f735a75278f14
+timeCreated: 1637930751

--- a/Packages/UGF.Module.Controllers/Runtime/Objects/ObjectRelativesController`1.cs
+++ b/Packages/UGF.Module.Controllers/Runtime/Objects/ObjectRelativesController`1.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using UGF.Application.Runtime;
+using UGF.RuntimeTools.Runtime.Objects;
+
+namespace UGF.Module.Controllers.Runtime.Objects
+{
+    public class ObjectRelativesController<TObject> : ControllerBase, IObjectRelativesController where TObject : class
+    {
+        public ObjectRelativesProvider<TObject> Provider { get; }
+
+        IObjectRelativeProvider IObjectRelativesController.Provider { get { return Provider; } }
+
+        public ObjectRelativesController(IApplication application) : this(application, new ObjectRelativesProvider<TObject>())
+        {
+        }
+
+        public ObjectRelativesController(IApplication application, ObjectRelativesProvider<TObject> provider) : base(application)
+        {
+            Provider = provider ?? throw new ArgumentNullException(nameof(provider));
+        }
+    }
+}

--- a/Packages/UGF.Module.Controllers/Runtime/Objects/ObjectRelativesController`1.cs.meta
+++ b/Packages/UGF.Module.Controllers/Runtime/Objects/ObjectRelativesController`1.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 3af3367509bb42e092606ca1d15085ef
+timeCreated: 1637930651

--- a/Packages/UGF.Module.Controllers/package.json
+++ b/Packages/UGF.Module.Controllers/package.json
@@ -19,7 +19,6 @@
     "registry": "https://unitygameframework.jfrog.io/artifactory/api/npm/default"
   },
   "dependencies": {
-    "com.ugf.application": "8.0.0-preview.9",
-    "com.ugf.editortools": "1.13.1"
+    "com.ugf.application": "8.0.0"
   }
 }

--- a/Packages/UGF.Module.Controllers/package.json
+++ b/Packages/UGF.Module.Controllers/package.json
@@ -2,7 +2,7 @@
   "name": "com.ugf.module.controllers",
   "displayName": "UGF.Module.Controllers",
   "version": "2.0.0-preview.7",
-  "unity": "2021.1",
+  "unity": "2021.2",
   "apiCompatibility": ".NET Standard 2.0",
   "description": "Module to manage multiple controllers in application.",
   "author": {

--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
     "com.unity.ide.rider": "3.0.7",
-    "com.unity.test-framework": "1.1.29"
+    "com.unity.test-framework": "1.1.30"
   },
   "scopedRegistries": [
     {

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -1,20 +1,22 @@
 {
   "dependencies": {
     "com.ugf.application": {
-      "version": "8.0.0-preview.9",
+      "version": "8.0.0",
       "depth": 1,
       "source": "registry",
       "dependencies": {
-        "com.ugf.initialize": "2.6.0",
+        "com.ugf.initialize": "2.7.0",
         "com.ugf.description": "2.0.0",
-        "com.ugf.runtimetools": "2.2.0",
-        "com.ugf.logs": "5.1.4"
+        "com.ugf.runtimetools": "2.4.0",
+        "com.ugf.logs": "5.2.0",
+        "com.ugf.editortools": "2.1.0",
+        "com.ugf.builder": "2.0.1"
       },
       "url": "https://unitygameframework.jfrog.io/artifactory/api/npm/default"
     },
     "com.ugf.builder": {
-      "version": "2.0.0",
-      "depth": 3,
+      "version": "2.0.1",
+      "depth": 2,
       "source": "registry",
       "dependencies": {},
       "url": "https://unitygameframework.jfrog.io/artifactory/api/npm/default"
@@ -30,12 +32,12 @@
       "url": "https://unitygameframework.jfrog.io/artifactory/api/npm/default"
     },
     "com.ugf.defines": {
-      "version": "2.1.4",
+      "version": "2.1.5",
       "depth": 3,
       "source": "registry",
       "dependencies": {
         "com.ugf.customsettings": "3.4.1",
-        "com.ugf.editortools": "1.11.0"
+        "com.ugf.editortools": "1.13.0"
       },
       "url": "https://unitygameframework.jfrog.io/artifactory/api/npm/default"
     },
@@ -49,25 +51,25 @@
       "url": "https://unitygameframework.jfrog.io/artifactory/api/npm/default"
     },
     "com.ugf.editortools": {
-      "version": "1.13.1",
-      "depth": 1,
+      "version": "2.1.0",
+      "depth": 2,
       "source": "registry",
       "dependencies": {},
       "url": "https://unitygameframework.jfrog.io/artifactory/api/npm/default"
     },
     "com.ugf.initialize": {
-      "version": "2.6.0",
+      "version": "2.7.0",
       "depth": 2,
       "source": "registry",
       "dependencies": {},
       "url": "https://unitygameframework.jfrog.io/artifactory/api/npm/default"
     },
     "com.ugf.logs": {
-      "version": "5.1.4",
+      "version": "5.2.0",
       "depth": 2,
       "source": "registry",
       "dependencies": {
-        "com.ugf.defines": "2.1.4"
+        "com.ugf.defines": "2.1.5"
       },
       "url": "https://unitygameframework.jfrog.io/artifactory/api/npm/default"
     },
@@ -76,12 +78,11 @@
       "depth": 0,
       "source": "embedded",
       "dependencies": {
-        "com.ugf.application": "8.0.0-preview.9",
-        "com.ugf.editortools": "1.13.1"
+        "com.ugf.application": "8.0.0"
       }
     },
     "com.ugf.runtimetools": {
-      "version": "2.2.0",
+      "version": "2.4.0",
       "depth": 2,
       "source": "registry",
       "dependencies": {},

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -104,7 +104,7 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.test-framework": {
-      "version": "1.1.29",
+      "version": "1.1.30",
       "depth": 0,
       "source": "registry",
       "dependencies": {

--- a/ProjectSettings/MemorySettings.asset
+++ b/ProjectSettings/MemorySettings.asset
@@ -1,0 +1,35 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!387306366 &1
+MemorySettings:
+  m_ObjectHideFlags: 0
+  m_EditorMemorySettings:
+    m_MainAllocatorBlockSize: -1
+    m_ThreadAllocatorBlockSize: -1
+    m_MainGfxBlockSize: -1
+    m_ThreadGfxBlockSize: -1
+    m_CacheBlockSize: -1
+    m_TypetreeBlockSize: -1
+    m_ProfilerBlockSize: -1
+    m_ProfilerEditorBlockSize: -1
+    m_BucketAllocatorGranularity: -1
+    m_BucketAllocatorBucketsCount: -1
+    m_BucketAllocatorBlockSize: -1
+    m_BucketAllocatorBlockCount: -1
+    m_ProfilerBucketAllocatorGranularity: -1
+    m_ProfilerBucketAllocatorBucketsCount: -1
+    m_ProfilerBucketAllocatorBlockSize: -1
+    m_ProfilerBucketAllocatorBlockCount: -1
+    m_TempAllocatorSizeMain: -1
+    m_JobTempAllocatorBlockSize: -1
+    m_BackgroundJobTempAllocatorBlockSize: -1
+    m_JobTempAllocatorReducedBlockSize: -1
+    m_TempAllocatorSizeGIBakingWorker: -1
+    m_TempAllocatorSizeNavMeshWorker: -1
+    m_TempAllocatorSizeAudioWorker: -1
+    m_TempAllocatorSizeCloudWorker: -1
+    m_TempAllocatorSizeGfx: -1
+    m_TempAllocatorSizeJobWorker: -1
+    m_TempAllocatorSizeBackgroundWorker: -1
+    m_TempAllocatorSizePreloadManager: -1
+  m_PlatformMemorySettings: {}

--- a/ProjectSettings/ProjectVersion.txt
+++ b/ProjectSettings/ProjectVersion.txt
@@ -1,2 +1,2 @@
-m_EditorVersion: 2021.1.19f1
-m_EditorVersionWithRevision: 2021.1.19f1 (5f5eb8bbdc25)
+m_EditorVersion: 2021.2.3f1
+m_EditorVersionWithRevision: 2021.2.3f1 (32358a8527b4)


### PR DESCRIPTION
- Update package Unity version to `2021.2`.
- Update dependencies: `com.ugf.application` to `8.0.0` version.
- Add `ObjectRelativesController<T>` class as controller to store `ObjectRelativesProvider<T>` provider.